### PR TITLE
[backend] バックエンドのレスポンスをモックからLLMの回答に置き換え #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,36 @@ bun run dev
 フロントエンドは http://localhost:5173 で起動します。
 
 ### バックエンド開発サーバー
+#### 1. OPENAI_API_KEYの設定
+* 下記の2ファイルの"your_key"の箇所にAI研究会のOPENAI_API_KEYを記載してください
+* 初回は`apps/backend/.env`を手動作成してください
+##### apps/backend/.env
+```
+OPENAI_API_KEY=your_key
+```
+
+##### apps/backend/wrangler.jsonc
+```
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "backend",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-06-07",
+  "compatibility_flags": [
+    "nodejs_compat"
+  ],
+  "vars": {
+    "OPENAI_API_KEY": "your_key"
+  }
+
+  (※以下省略)
+
+}
+
+```
+
+
+#### 2. 起動コマンド
 ```bash
 cd apps/backend
 docker-compose up -d # VoiceVox コンテナの起動

--- a/README.md
+++ b/README.md
@@ -49,13 +49,7 @@ bun run dev
 
 ### バックエンド開発サーバー
 #### 1. OPENAI_API_KEYの設定
-* 下記の2ファイルの"your_key"の箇所にAI研究会のOPENAI_API_KEYを記載してください
-* 初回は`apps/backend/.env`を手動作成してください
-##### apps/backend/.env
-```
-OPENAI_API_KEY=your_key
-```
-
+* 下記のファイルの"your_key"の箇所にAI研究会のOPENAI_API_KEYを記載してください
 ##### apps/backend/wrangler.jsonc
 ```
 {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,7 +7,6 @@
   },
   "dependencies": {
     "buffer": "^6.0.3",
-    "dotenv": "^17.2.1",
     "hono": "^4.7.11",
     "openai": "^5.12.2"
   },

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,7 +7,9 @@
   },
   "dependencies": {
     "buffer": "^6.0.3",
-    "hono": "^4.7.11"
+    "dotenv": "^17.2.1",
+    "hono": "^4.7.11",
+    "openai": "^5.12.2"
   },
   "devDependencies": {
     "wrangler": "^4.4.0"

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -32,7 +32,7 @@ app.post("/api/zundamon/voice-chat", async (c) => {
 
   try {
     // LLMによる回答生成
-    const speechText = await generateResponse(message)
+    const speechText = await generateResponse(message);
 
     // 音声合成
     const audioBase64 = await generateSpeech(speechText, 1);

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -2,9 +2,6 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { generateSpeech } from "./services/voicevox/generateSpeech";
 import { generateResponse } from "./services/llmServices/chatAgent";
-import dotenv from "dotenv";
-
-dotenv.config();
 
 const app = new Hono();
 

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -2,6 +2,9 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { generateSpeech } from "./services/voicevox/generateSpeech";
 import { generateResponse } from "./services/llmServices/chatAgent";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 const app = new Hono();
 

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { generateSpeech } from "./services/voicevox/generateSpeech";
+import { generateResponse } from "./services/llmServices/chatAgent";
 
 const app = new Hono();
 
@@ -13,24 +14,11 @@ app.use(
   }),
 );
 
-const ZUNDAMON_RESPONSES = [
-  "そうなのだ！とても面白いのだ！",
-  "なるほどなのだ〜、勉強になるのだ！",
-  "ずんだもんも同じことを思っていたのだ！",
-  "それは素晴らしいアイデアなのだ！",
-  "もっと詳しく教えてほしいのだ〜",
-  "ずんだもんはそれが大好きなのだ！",
-  "とても興味深い話なのだ！",
-  "一緒に考えてみるのだ〜",
-  "それはとても大切なことなのだ！",
-  "ずんだもんも応援するのだ〜！",
-];
-
 app.get("/", (c) => {
   return c.text("Hello Hono!");
 });
 
-// Voice Chat API (現在はテキストのモック)
+// Voice Chat API
 app.post("/api/zundamon/voice-chat", async (c) => {
   const body = await c.req.json();
   const { message } = body;
@@ -40,9 +28,8 @@ app.post("/api/zundamon/voice-chat", async (c) => {
   }
 
   try {
-    // ランダムな返答を選択
-    const randomIndex = Math.floor(Math.random() * ZUNDAMON_RESPONSES.length);
-    const speechText = ZUNDAMON_RESPONSES[randomIndex];
+    // LLMによる回答生成
+    const speechText = await generateResponse(message)
 
     // 音声合成
     const audioBase64 = await generateSpeech(speechText, 1);

--- a/apps/backend/src/services/llmServices/chatAgent.ts
+++ b/apps/backend/src/services/llmServices/chatAgent.ts
@@ -1,24 +1,48 @@
 import OpenAI from "openai";
-import dotenv from 'dotenv';
+import { zodTextFormat } from "openai/helpers/zod";
+import { z } from "zod";
+import dotenv from "dotenv";
 dotenv.config();
 
 const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-const INSTRUCTIONS = "* 語尾に'なのだ'または'のだ'を付けて20字程度で回答してください\n* 回答は1つのみとしてください";
+// 回答の最大文字数定義
+const ANSWER_MAX_LENGTH = 30;
+
+const INSTRUCTIONS = `
+* 語尾に'なのだ'または'のだ'を付けて${ANSWER_MAX_LENGTH}字以内で回答してください
+* 回答は1つのみとしてください
+`;
+
 let prevId: string | undefined;
 
+// LLM回答のスキーマ定義
+const chatResponseSchema = z.object({
+  answer: z
+    .string()
+    .max(ANSWER_MAX_LENGTH)
+    .describe("ユーザーの質問に対する回答"),
+});
+
 export async function generateResponse(userMessage: string) {
-    const q = userMessage;
+  const res = await client.responses.parse({
+    model: "gpt-5-2025-08-07",
+    input: [{ role: "user", content: userMessage }],
+    previous_response_id: prevId,
+    instructions: INSTRUCTIONS,
+    text: {
+      format: zodTextFormat(chatResponseSchema, "chat_response"),
+    },
+  });
 
-    const res = await client.responses.create({
-      model: "gpt-5-2025-08-07",
-      input: [{ role: "user", content: q }],
-      previous_response_id: prevId,
-      instructions: INSTRUCTIONS,
-    });
+  const parsed = res.output_parsed;
 
-    console.log(res.output_text);
-    prevId = res.id; // 会話履歴の保持用ID
+  if (!parsed) {
+    throw new Error("LLM output does not match the schema.");
+  }
 
-    return res.output_text;
+  console.log(`generatedAnswer: ${parsed.answer}`);
+  prevId = res.id; // 会話履歴の保持用ID
+
+  return parsed.answer;
 }

--- a/apps/backend/src/services/llmServices/chatAgent.ts
+++ b/apps/backend/src/services/llmServices/chatAgent.ts
@@ -1,0 +1,24 @@
+import OpenAI from "openai";
+import dotenv from 'dotenv';
+dotenv.config();
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const INSTRUCTIONS = "* 語尾に'なのだ'または'のだ'を付けて20字程度で回答してください\n* 回答は1つのみとしてください";
+let prevId: string | undefined;
+
+export async function generateResponse(userMessage: string) {
+    const q = userMessage;
+
+    const res = await client.responses.create({
+      model: "gpt-5-2025-08-07",
+      input: [{ role: "user", content: q }],
+      previous_response_id: prevId,
+      instructions: INSTRUCTIONS,
+    });
+
+    console.log(res.output_text);
+    prevId = res.id; // 会話履歴の保持用ID
+
+    return res.output_text;
+}

--- a/apps/backend/src/services/llmServices/chatAgent.ts
+++ b/apps/backend/src/services/llmServices/chatAgent.ts
@@ -33,6 +33,8 @@ export async function generateResponse(userMessage: string) {
     text: {
       format: zodTextFormat(chatResponseSchema, "chat_response"),
     },
+    tools: [{ type: "web_search_preview" }],
+    tool_choice: "auto", // 必要に応じてweb search
   });
 
   const parsed = res.output_parsed;

--- a/apps/backend/src/services/llmServices/chatAgent.ts
+++ b/apps/backend/src/services/llmServices/chatAgent.ts
@@ -1,8 +1,6 @@
 import OpenAI from "openai";
 import { zodTextFormat } from "openai/helpers/zod";
 import { z } from "zod";
-import dotenv from "dotenv";
-dotenv.config();
 
 const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 

--- a/apps/backend/wrangler.jsonc
+++ b/apps/backend/wrangler.jsonc
@@ -2,13 +2,13 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "backend",
   "main": "src/index.ts",
-  "compatibility_date": "2025-06-07"
-  // "compatibility_flags": [
-  //   "nodejs_compat"
-  // ],
-  // "vars": {
-  //   "MY_VAR": "my-variable"
-  // },
+  "compatibility_date": "2025-06-07",
+  "compatibility_flags": [
+    "nodejs_compat"
+  ],
+  "vars": {
+    "OPENAI_API_KEY": "your_key"
+  }
   // "kv_namespaces": [
   //   {
   //     "binding": "MY_KV_NAMESPACE",

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,6 @@
       "name": "backend",
       "dependencies": {
         "buffer": "^6.0.3",
-        "dotenv": "^17.2.1",
         "hono": "^4.7.11",
         "openai": "^5.12.2",
       },
@@ -480,8 +479,6 @@
     "detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
-
-    "dotenv": ["dotenv@17.2.1", "", {}, "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,9 @@
       "name": "backend",
       "dependencies": {
         "buffer": "^6.0.3",
+        "dotenv": "^17.2.1",
         "hono": "^4.7.11",
+        "openai": "^5.12.2",
       },
       "devDependencies": {
         "wrangler": "^4.4.0",
@@ -479,6 +481,8 @@
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
+    "dotenv": ["dotenv@17.2.1", "", {}, "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.165", "", {}, "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw=="],
@@ -760,6 +764,8 @@
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "openai": ["openai@5.12.2", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 


### PR DESCRIPTION
@daichihayasaka 
下記の内容を実装しました！
ご確認よろしくお願いいたします。

## 対応済み内容
- [x]  openai sdk を依存関係に追加
- [x]  gpt-4.1 を使う 最新のスナップショットを適用 
    - 一旦は"gpt-5-2025-08-07"にしておく
- [x]  response api を利用
    - [x]  https://platform.openai.com/docs/guides/text?api-mode=responses 
    - [x]  履歴管理
        - [x]  https://platform.openai.com/docs/guides/conversation-state?api-mode=responses
    - [x]  output が複数になる問題の解決策
        - [x]  instructions に `“Please return one complete answer and then stop.”` を 入れる
            - [x]  参考:  https://github.com/UnicastInc/llm-talk-generator/issues/22#issuecomment-2947856480
- [x]  ずんだもん口調にする
- [x]  structured output を使う
    - [x]  https://platform.openai.com/docs/guides/structured-outputs?api-mode=responses 
- [x]  web search も導入しちゃう？
- [x]  llm を call する処理は src/services/llmServices に実装
    - apps/backend/src/services/llmServices/chatAgent.ts

## 未対応の内容(別Issue化済み、後のアップデートで対応予定です)
* ブラウザリロードで会話履歴をリセット #27 
* WebSearchを実行しているかの見える化と、レスポンススキーマに参照URLを含めるようにする #28 