### PR TITLE
[backend] Swagger UI の導入 #15

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -8,8 +8,8 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
-    "@hono/swagger-ui": "^0.6.0",
-    "@hono/zod-openapi": "^0.21.0",
+    "@hono/swagger-ui": "^0.2.0",
+    "@hono/zod-openapi": "^0.15.0",
     "buffer": "^6.0.3",
     "hono": "^4.7.11",
     "openai": "^5.12.2",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -8,9 +8,12 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
+    "@hono/swagger-ui": "^0.6.0",
+    "@hono/zod-openapi": "^0.21.0",
     "buffer": "^6.0.3",
     "hono": "^4.7.11",
-    "openai": "^5.12.2"
+    "openai": "^5.12.2",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.8.65",

--- a/apps/backend/src/config/cors.ts
+++ b/apps/backend/src/config/cors.ts
@@ -1,0 +1,8 @@
+/**
+ * CORS configuration for the AI Avatar API
+ */
+export const corsConfig = {
+  origin: ["http://localhost:5173"],
+  allowMethods: ["GET", "POST"],
+  allowHeaders: ["Content-Type"],
+} as const;

--- a/apps/backend/src/config/openapi.ts
+++ b/apps/backend/src/config/openapi.ts
@@ -1,0 +1,10 @@
+/**
+ * OpenAPI configuration for the AI Avatar API
+ */
+export const openApiConfig = {
+  openapi: "3.0.0",
+  info: {
+    version: "1.0.0",
+    title: "AI Avatar API",
+  },
+} as const;

--- a/apps/backend/src/controllers/voice-chat.ts
+++ b/apps/backend/src/controllers/voice-chat.ts
@@ -1,0 +1,36 @@
+import type { Context } from "hono";
+import type { Bindings } from "../types";
+import { generateResponse } from "../services/llmServices/chatAgent";
+import { generateSpeech } from "../services/voicevox/generateSpeech";
+
+/**
+ * Controller for voice chat endpoint
+ * Handles the business logic for processing voice chat requests
+ */
+export async function handleVoiceChat(c: Context<{ Bindings: Bindings }>) {
+  const body = await c.req.json();
+  const { message } = body;
+
+  if (!message || typeof message !== "string") {
+    return c.json({ error: "Message is required" }, 400);
+  }
+
+  try {
+    // LLMによる回答生成
+    const speechText = await generateResponse(message, c.env.OPENAI_API_KEY);
+
+    // 音声合成
+    const audioBase64 = await generateSpeech(speechText, 1);
+
+    return c.json({
+      userMessage: message,
+      zundamonResponse: speechText,
+      audioBase64: audioBase64,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error(error);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+}

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,5 +1,7 @@
-import { Hono } from "hono";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { swaggerUI } from "@hono/swagger-ui";
 import { cors } from "hono/cors";
+import { z } from "zod";
 import { generateResponse } from "./services/llmServices/chatAgent";
 import { generateSpeech } from "./services/voicevox/generateSpeech";
 
@@ -7,7 +9,17 @@ type Bindings = {
   OPENAI_API_KEY: string;
 };
 
-const app = new Hono<{ Bindings: Bindings }>();
+const app = new OpenAPIHono<{ Bindings: Bindings }>();
+
+app.doc("/doc", {
+  openapi: "3.0.0",
+  info: {
+    version: "1.0.0",
+    title: "AI Avatar API",
+  },
+});
+
+app.get("/ui", swaggerUI({ url: "/doc" }));
 
 app.use(
   "/*",
@@ -22,33 +34,87 @@ app.get("/", (c) => {
   return c.text("Hello Hono!");
 });
 
-// Voice Chat API
-app.post("/api/zundamon/voice-chat", async (c) => {
-  const body = await c.req.json();
-  const { message } = body;
+// Voice Chat API with OpenAPI schema
+const voiceChatRoute = app.openapi(
+  {
+    method: "post",
+    path: "/api/zundamon/voice-chat",
+    request: {
+      body: {
+        content: {
+          "application/json": {
+            schema: z.object({
+              message: z.string().min(1).describe("User message to send to AI avatar"),
+            }),
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            schema: z.object({
+              userMessage: z.string().describe("Original user message"),
+              zundamonResponse: z.string().describe("AI avatar response text"),
+              audioBase64: z.string().describe("Base64 encoded audio of the response"),
+              timestamp: z.string().describe("ISO timestamp"),
+            }),
+          },
+        },
+        description: "Successful voice chat response",
+      },
+      400: {
+        content: {
+          "application/json": {
+            schema: z.object({
+              error: z.string(),
+            }),
+          },
+        },
+        description: "Bad request - invalid input",
+      },
+      500: {
+        content: {
+          "application/json": {
+            schema: z.object({
+              error: z.string(),
+            }),
+          },
+        },
+        description: "Internal server error",
+      },
+    },
+    tags: ["Voice Chat"],
+    summary: "Send message to AI avatar and get voice response",
+  },
+  async (c) => {
+    const body = await c.req.json();
+    const { message } = body;
 
-  if (!message || typeof message !== "string") {
-    return c.json({ error: "Message is required" }, 400);
-  }
+    if (!message || typeof message !== "string") {
+      return c.json({ error: "Message is required" }, 400);
+    }
 
-  try {
-    // LLMによる回答生成
-    const speechText = await generateResponse(message, c.env.OPENAI_API_KEY);
+    try {
+      // LLMによる回答生成
+      const speechText = await generateResponse(message, c.env.OPENAI_API_KEY);
 
-    // 音声合成
-    const audioBase64 = await generateSpeech(speechText, 1);
+      // 音声合成
+      const audioBase64 = await generateSpeech(speechText, 1);
 
-    return c.json({
-      userMessage: message,
-      zundamonResponse: speechText,
-      audioBase64: audioBase64,
-      timestamp: new Date().toISOString(),
-    });
-  } catch (error) {
-    console.error(error);
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return c.json({ error: "Internal server error" }, 500);
-  }
-});
+      return c.json({
+        userMessage: message,
+        zundamonResponse: speechText,
+        audioBase64: audioBase64,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error) {
+      console.error(error);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return c.json({ error: "Internal server error" }, 500);
+    }
+  },
+);
 
 export default app;

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,120 +1,28 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { swaggerUI } from "@hono/swagger-ui";
 import { cors } from "hono/cors";
-import { z } from "zod";
-import { generateResponse } from "./services/llmServices/chatAgent";
-import { generateSpeech } from "./services/voicevox/generateSpeech";
-
-type Bindings = {
-  OPENAI_API_KEY: string;
-};
+import type { Bindings } from "./types";
+import { openApiConfig } from "./config/openapi";
+import { corsConfig } from "./config/cors";
+import { registerVoiceChatRoutes } from "./routes/voice-chat";
 
 const app = new OpenAPIHono<{ Bindings: Bindings }>();
 
-app.doc("/doc", {
-  openapi: "3.0.0",
-  info: {
-    version: "1.0.0",
-    title: "AI Avatar API",
-  },
-});
+// OpenAPI documentation endpoint
+app.doc("/doc", openApiConfig);
 
+// Swagger UI endpoint
 app.get("/ui", swaggerUI({ url: "/doc" }));
 
-app.use(
-  "/*",
-  cors({
-    origin: ["http://localhost:5173"],
-    allowMethods: ["GET", "POST"],
-    allowHeaders: ["Content-Type"],
-  }),
-);
+// CORS middleware
+app.use("/*", cors(corsConfig));
 
+// Health check endpoint
 app.get("/", (c) => {
   return c.text("Hello Hono!");
 });
 
-// Voice Chat API with OpenAPI schema
-const voiceChatRoute = app.openapi(
-  {
-    method: "post",
-    path: "/api/zundamon/voice-chat",
-    request: {
-      body: {
-        content: {
-          "application/json": {
-            schema: z.object({
-              message: z.string().min(1).describe("User message to send to AI avatar"),
-            }),
-          },
-        },
-      },
-    },
-    responses: {
-      200: {
-        content: {
-          "application/json": {
-            schema: z.object({
-              userMessage: z.string().describe("Original user message"),
-              zundamonResponse: z.string().describe("AI avatar response text"),
-              audioBase64: z.string().describe("Base64 encoded audio of the response"),
-              timestamp: z.string().describe("ISO timestamp"),
-            }),
-          },
-        },
-        description: "Successful voice chat response",
-      },
-      400: {
-        content: {
-          "application/json": {
-            schema: z.object({
-              error: z.string(),
-            }),
-          },
-        },
-        description: "Bad request - invalid input",
-      },
-      500: {
-        content: {
-          "application/json": {
-            schema: z.object({
-              error: z.string(),
-            }),
-          },
-        },
-        description: "Internal server error",
-      },
-    },
-    tags: ["Voice Chat"],
-    summary: "Send message to AI avatar and get voice response",
-  },
-  async (c) => {
-    const body = await c.req.json();
-    const { message } = body;
-
-    if (!message || typeof message !== "string") {
-      return c.json({ error: "Message is required" }, 400);
-    }
-
-    try {
-      // LLMによる回答生成
-      const speechText = await generateResponse(message, c.env.OPENAI_API_KEY);
-
-      // 音声合成
-      const audioBase64 = await generateSpeech(speechText, 1);
-
-      return c.json({
-        userMessage: message,
-        zundamonResponse: speechText,
-        audioBase64: audioBase64,
-        timestamp: new Date().toISOString(),
-      });
-    } catch (error) {
-      console.error(error);
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      return c.json({ error: "Internal server error" }, 500);
-    }
-  },
-);
+// Register route handlers
+registerVoiceChatRoutes(app);
 
 export default app;

--- a/apps/backend/src/routes/voice-chat.ts
+++ b/apps/backend/src/routes/voice-chat.ts
@@ -1,0 +1,11 @@
+import type { OpenAPIHono } from "@hono/zod-openapi";
+import type { Bindings } from "../types";
+import { voiceChatRouteDefinition } from "../schemas/voice-chat";
+import { handleVoiceChat } from "../controllers/voice-chat";
+
+/**
+ * Registers voice chat routes with the Hono app
+ */
+export function registerVoiceChatRoutes(app: OpenAPIHono<{ Bindings: Bindings }>) {
+  app.openapi(voiceChatRouteDefinition, handleVoiceChat);
+}

--- a/apps/backend/src/schemas/voice-chat.ts
+++ b/apps/backend/src/schemas/voice-chat.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+/**
+ * Request schema for voice chat endpoint
+ */
+export const voiceChatRequestSchema = z.object({
+  message: z.string().min(1).describe("User message to send to AI avatar"),
+});
+
+/**
+ * Response schema for successful voice chat
+ */
+export const voiceChatResponseSchema = z.object({
+  userMessage: z.string().describe("Original user message"),
+  zundamonResponse: z.string().describe("AI avatar response text"),
+  audioBase64: z.string().describe("Base64 encoded audio of the response"),
+  timestamp: z.string().describe("ISO timestamp"),
+});
+
+/**
+ * Error response schema
+ */
+export const errorResponseSchema = z.object({
+  error: z.string(),
+});
+
+/**
+ * OpenAPI route definition for voice chat endpoint
+ */
+export const voiceChatRouteDefinition = {
+  method: "post",
+  path: "/api/zundamon/voice-chat",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: voiceChatRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: voiceChatResponseSchema,
+        },
+      },
+      description: "Successful voice chat response",
+    },
+    400: {
+      content: {
+        "application/json": {
+          schema: errorResponseSchema,
+        },
+      },
+      description: "Bad request - invalid input",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: errorResponseSchema,
+        },
+      },
+      description: "Internal server error",
+    },
+  },
+  tags: ["Voice Chat"],
+  summary: "Send message to AI avatar and get voice response",
+} as const;

--- a/apps/backend/src/types/index.ts
+++ b/apps/backend/src/types/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Common type definitions used across the application
+ */
+export type Bindings = {
+  OPENAI_API_KEY: string;
+};


### PR DESCRIPTION
Swagger UIを最小限の実装で導入しました。

## 変更内容
- @hono/swagger-ui、@hono/zod-openapi、zod依存関係を追加
- OpenAPIHonoへ移行してOpenAPIサポートを有効化
- /docエンドポイントでOpenAPI JSONを提供
- /uiエンドポイントでSwagger UIを提供
- 既存Voice Chat APIをOpenAPIスキーマ対応に変換
- 後方互換性を維持

## 利用可能エンドポイント
- Swagger UI: http://localhost:8787/ui
- OpenAPI JSON: http://localhost:8787/doc
- Voice Chat API: http://localhost:8787/api/zundamon/voice-chat

Closes #15

Generated with [Claude Code](https://claude.ai/code)