### PR TITLE
Claude Code Action のブランチ名変更処理が動作しない問題を修正 #48

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,28 +51,40 @@ jobs:
       - name: Rename branch to follow project convention
         if: github.event_name == 'issues' || github.event_name == 'issue_comment'
         run: |
-          # Get the current branch name
-          CURRENT_BRANCH=$(git branch --show-current)
+          # Wait for Claude Code Action to complete branch creation
+          sleep 10
           
-          # Check if this is a Claude-created branch for an issue
-          if [[ "$CURRENT_BRANCH" == claude/issue-* ]]; then
-            # Extract issue number from the current branch name
-            ISSUE_NUMBER="${{ github.event.issue.number }}"
+          # Fetch all remote branches
+          git fetch --all
+          
+          # Get the issue number
+          ISSUE_NUMBER="${{ github.event.issue.number }}"
+          
+          # Look for Claude-created branch in remote
+          CLAUDE_BRANCH=$(git branch -r | grep -E "origin/claude/issue-${ISSUE_NUMBER}-" | sed 's/.*origin\///' | head -n 1)
+          
+          if [ -n "$CLAUDE_BRANCH" ]; then
             NEW_BRANCH="feature/#${ISSUE_NUMBER}"
             
-            echo "Renaming branch from $CURRENT_BRANCH to $NEW_BRANCH"
+            echo "Found Claude branch: $CLAUDE_BRANCH"
+            echo "Renaming to: $NEW_BRANCH"
             
-            # Rename the local branch
-            git branch -m "$NEW_BRANCH"
+            # Fetch the specific branch
+            git fetch origin "$CLAUDE_BRANCH"
+            
+            # Create new branch from Claude branch
+            git checkout -b "$NEW_BRANCH" "origin/$CLAUDE_BRANCH"
             
             # Push the new branch to remote
             git push origin "$NEW_BRANCH"
             
             # Delete the old branch from remote
-            git push origin --delete "$CURRENT_BRANCH" || true
+            git push origin --delete "$CLAUDE_BRANCH" || true
             
             echo "Branch renamed successfully to $NEW_BRANCH"
           else
-            echo "Branch $CURRENT_BRANCH is not a Claude issue branch, skipping rename"
+            echo "No Claude branch found for issue #${ISSUE_NUMBER}"
+            echo "Available remote branches:"
+            git branch -r | grep claude || echo "No claude branches found"
           fi
 


### PR DESCRIPTION
## Summary
Claude Code Action のブランチ名変更処理を修正し、リモートブランチを正しく検出してリネームするように改善

## Problem
#46 でブランチ名を自動変更する処理を追加したが、#45 でテストした際に動作しなかった

## Root Cause
Claude Code Action がブランチを作成してプッシュするが、GitHub Actions のワークフロー内ではローカルのチェックアウトが変更されないため、`git branch --show-current` が期待するブランチを返さない

## Changes
- Claude Code Action の完了を待つため 10 秒の待機を追加
- リモートブランチから Claude ブランチを検出するように変更
- 正しくチェックアウトしてから新ブランチを作成
- デバッグ用のログ出力を追加

## Test plan
- [ ] Issue で Claude Code Action をトリガー
- [ ] Claude がブランチを作成後、自動的に `feature/#<issue番号>` にリネームされることを確認
- [ ] 古い `claude/issue-*` ブランチが削除されることを確認

Closes #48

🤖 Generated with [Claude Code](https://claude.ai/code)